### PR TITLE
Preventing negative numbers

### DIFF
--- a/numeric/jquery.numeric.js
+++ b/numeric/jquery.numeric.js
@@ -30,7 +30,9 @@
 $.fn.numeric = function(config, callback)
 {
 	config = config || {};
-	
+	if(typeof config === 'boolean') {
+		config = { decimal: config };
+	}	
 	var decimal = (config.decimal === false) ? "" : config.decimal || ".";
 	var negative = (config.negative === true) ? true : false;
 	var callback = typeof config.callback == "function" ? config.callback : function(){};


### PR DESCRIPTION
On my project, we very often need to restrain users to positive numbers, so I changed numeric() to take an object literal. Another change I might make in the future is another option to universally allow a keystroke if a modifier key (i.e. alt/ctrl/cmd) is held down.

I realize that this signature change would break backwards compatibility, but I think the object literal with an explicit config would make the options more apparent to users (I got stuck trying to declare no decimal by specifying '' at first).
