### PR TITLE
Numeric: onblur callback function is not being called for inputs that contains numbers such as 123a123 

### DIFF
--- a/numeric/jquery.numeric.js
+++ b/numeric/jquery.numeric.js
@@ -228,7 +228,7 @@ $.fn.numeric.blur = function()
 	var val = this.value;
 	if(val != "")
 	{
-		var re = new RegExp("^\\d+$|\\d*" + decimal + "\\d+");
+		var re = new RegExp("^\\d+$|^\\d*" + decimal + "\\d+$");
 		if(!re.exec(val))
 		{
 			callback.apply(this);


### PR DESCRIPTION
Fixed the regex with $ and ^ anchors to that the validation matches the entire input.
