### PR TITLE
Typo in call to jQuery val() function

### DIFF
--- a/numeric/jquery.numeric.js
+++ b/numeric/jquery.numeric.js
@@ -139,7 +139,7 @@ $.fn.numeric.keypress = function(e)
 
 $.fn.numeric.keyup = function(e)
 {
-	var val = $(this).value;
+	var val = $(this).val();
 	if(val && val.length > 0)
 	{
 		// get carat (cursor) position


### PR DESCRIPTION
There is a typo in line 124: instead of calling jQuery `val()` function `value` property is used. The result of this operation is undefined and it prevents the plugin from removing not numeric characters when you paste via Ctrl+V.
