### PR TITLE
addOption fix for select boxes

### DIFF
--- a/selectboxes/jquery.selectboxes.js
+++ b/selectboxes/jquery.selectboxes.js
@@ -110,8 +110,10 @@ $.fn.addOption = function()
 			{
 				for(var item in items)
 				{
-					add(this, item, items[item], sO, startindex);
-					startindex += 1;
+					if(items.hasOwnProperty(item)){
+						add(this, item, items[item], sO, startindex);
+						startindex += 1;
+					}
 				}
 			}
 			else


### PR DESCRIPTION
Fixed for in loop in addOption for use with a prototype based library. Added a hasOwnProperty qualifier to avoid adding the array's prototyped properties to the selectbox
