### PR TITLE
Fixed ctrl+A selection, keyboard selection

### DIFF
--- a/numeric/jquery.numeric.js
+++ b/numeric/jquery.numeric.js
@@ -144,6 +144,7 @@ $.fn.numeric.keyup = function(e)
 	{
 		// get carat (cursor) position
 		var carat = $.fn.getSelectionStart(this);
+		var selectionEnd = $.fn.getSelectionEnd(this);
 		// get decimal character and determine if negatives are allowed
 		var decimal = $.data(this, "numeric.decimal");
 		var negative = $.data(this, "numeric.negative");
@@ -217,7 +218,7 @@ $.fn.numeric.keyup = function(e)
 		}
 		// set the value and prevent the cursor moving to the end
 		this.value = val;
-		$.fn.setSelection(this, carat);
+		$.fn.setSelection(this, [carat, selectionEnd]);
 	}
 };
 
@@ -252,6 +253,16 @@ $.fn.getSelectionStart = function(o)
 		return o.value.lastIndexOf(r.text);
 	} else { return o.selectionStart; }
 };
+
+// Based on code from http://javascript.nwbox.com/cursor_position/ (Diego Perini <dperini@nwbox.com>)
+$.fn.getSelectionEnd = function(o)
+{
+	if (o.createTextRange) {
+		var r = document.selection.createRange().duplicate()
+		r.moveStart('character', -o.value.length)
+		return r.text.length
+	} else return o.selectionEnd
+}
 
 // set the selection, o is the object (input), p is the position ([start, end] or just start)
 $.fn.setSelection = function(o, p)


### PR DESCRIPTION
Previously, each time the keyup callback function was called, the selection was reset to only where the carat was (start and end of selection being the same). To enable use of ctrl+A and shift+right/shift+left to do selection, the end of selection also had to be saved.

To do this, another function from Diego Perini dperini@nwbox.com was added to get the selection end, and this was used in the keyup function.

Note: shift+left to selection more than one character still appears to not work.
