### PR TITLE
Allow addOption to take an array of {"val":"text"} objects as a parameter as well as the default parameter type

### DIFF
--- a/selectboxes/jquery.selectboxes.js
+++ b/selectboxes/jquery.selectboxes.js
@@ -110,14 +110,14 @@ $.fn.addOption = function()
 			{
 				var sel = this;
 				jQuery.each(items, function(val, text){
-						if(typeof(text) == "object"){
-							jQuery.each(text, function(k,v){
-								val = k;
-								text = v;
-							});
-						}
-						add(sel, val, text, sO, startindex);
-						startindex += 1; 
+					if(typeof(text) == "object"){
+						jQuery.each(text, function(k,v){
+							val = k;
+							text = v;
+						});
+					}
+					add(sel, val, text, sO, startindex);
+					startindex += 1; 
 				});
 			}
 			else


### PR DESCRIPTION
This will allow options to keep their order when they are brought in via AJAX. Chrome sorts objects by their keys
