### PR TITLE
Fix ie

### DIFF
--- a/numeric/jquery.numeric.js
+++ b/numeric/jquery.numeric.js
@@ -259,7 +259,7 @@ $.fn.getSelectionStart = function(o)
 		if (r.text == '') return o.value.length;
 
 		return o.value.lastIndexOf(r.text);
-	} else return o.selectionStart;
+	} else { return o.selectionStart; }
 };
 
 // Based on code from http://javascript.nwbox.com/cursor_position/ (Diego Perini <dperini@nwbox.com>)


### PR DESCRIPTION
Jquery numeric
On IE11 document.selection is deprecated. They suggest to use "document.getSelection()" instead.
http://msdn.microsoft.com/en-us/library/ie/bg182625(v=vs.85).aspx

So here I check if old style is supported, if not try to use another function.
This fixes https://github.com/SamWM/jQuery-Plugins/issues/62 issue
