### PR TITLE
Fix input numeric input when decimal places full (#78)

### DIFF
--- a/numeric/jquery.numeric.js
+++ b/numeric/jquery.numeric.js
@@ -146,8 +146,10 @@ $.fn.numeric.keypress = function(e)
         // remove extra decimal places
  		if(decimal && decimalPlaces > 0)
  		{
+            var selectionStart = $.fn.getSelectionStart(this);
+            var selectionEnd = $.fn.getSelectionEnd(this);
             var dot = $.inArray(decimal, $(this).val().split(''));
-            if (dot >= 0 && $(this).val().length > dot + decimalPlaces) {
+            if (selectionStart === selectionEnd && dot >= 0 && selectionStart > dot && $(this).val().length > dot + decimalPlaces) {
                 allow = false;
             }
         }


### PR DESCRIPTION
Fix for bug #78 

This fix solves the issue of the input not allowing further change to the input when it is already filled with a number to the maximum number of decimal places specified. The user will now be able to enter more numeric digits to the left of the decimal point, as well enter numbers when a portion of input text is selected.