### PR TITLE
Allow using '.' key to insert non standard decimal separator.

### DIFF
--- a/numeric/jquery.numeric.js
+++ b/numeric/jquery.numeric.js
@@ -143,6 +143,10 @@ $.fn.numeric.keypress = function(e)
 				allow = false;
 			}
 		}
+		//if the key pressed is '.' and the decimal symbol is not present yet, add it to the field.
+		else if(key == 46 && $.inArray(decimal, value.split('')) == -1){
+			this.value += decimal;
+		}
 	}
 	else
 	{

--- a/numeric/jquery.numeric.js
+++ b/numeric/jquery.numeric.js
@@ -145,7 +145,7 @@ $.fn.numeric.keypress = function(e)
 		}
 		//if the key pressed is '.' and the decimal symbol is not present yet, add it to the field.
 		else if(decimal && key == 46 && $.inArray(decimal, value.split('')) == -1){
-			$(this).val($(this).val()+ decimal);
+			$(this).val($(this).val() + decimal);
 		}
 	}
 	else
@@ -161,7 +161,6 @@ $.fn.numeric.keypress = function(e)
                 allow = false;
             }
         }
-
 	}
 	return allow;
 };

--- a/numeric/jquery.numeric.js
+++ b/numeric/jquery.numeric.js
@@ -143,6 +143,10 @@ $.fn.numeric.keypress = function(e)
 				allow = false;
 			}
 		}
+		//if the key pressed is '.' and the decimal symbol is not present yet, add it to the field.
+		else if(decimal && key == 46 && $.inArray(decimal, value.split('')) == -1){
+			$(this).val($(this).val()+ decimal);
+		}
 	}
 	else
 	{

--- a/numeric/jquery.numeric.js
+++ b/numeric/jquery.numeric.js
@@ -143,10 +143,6 @@ $.fn.numeric.keypress = function(e)
 				allow = false;
 			}
 		}
-		//if the key pressed is '.' and the decimal symbol is not present yet, add it to the field.
-		else if(key == 46 && $.inArray(decimal, value.split('')) == -1){
-			this.value += decimal;
-		}
 	}
 	else
 	{


### PR DESCRIPTION
When using a non standard decimal separator, such as comma ',' allow the user to insert the decimal separator using the '.' key.
